### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,14 @@ add_executable(pshell
         shell.h
         cmd_parser.c)
 
+target_compile_options(pshell
+    PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+)
+
 set(SANITIZE_FLAGS "-fsanitize=address,undefined")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
 
 include(CheckCCompilerFlag)
 CHECK_C_COMPILER_FLAG("${SANITIZE_FLAGS}" COMPILER_SUPPORTS_SANITIZERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,22 @@ target_compile_options(pshell
         -Wpedantic
 )
 
-set(SANITIZE_FLAGS "-fsanitize=address,undefined")
-
 include(CheckCCompilerFlag)
-CHECK_C_COMPILER_FLAG("${SANITIZE_FLAGS}" COMPILER_SUPPORTS_SANITIZERS)
-if(COMPILER_SUPPORTS_SANITIZERS)
-    message(STATUS "Compiler supports sanitizers")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZE_FLAGS}")
+
+check_c_compiler_flag("-fsanitize=address" COMPILER_SUPPORTS_ASAN)
+if(COMPILER_SUPPORTS_ASAN)
+    message(STATUS "Compiler supports AddressSanitizer")
+    target_compile_options(pshell PRIVATE -fsanitize=address)
+    target_link_libraries(pshell PRIVATE -fsanitize=address)
 else()
-    message(WARNING "Compiler does not support sanitizers")
+    message(WARNING "Compiler does not support AddressSanitizer")
+endif()
+
+check_c_compiler_flag("-fsanitize=undefined" COMPILER_SUPPORTS_UBSAN)
+if(COMPILER_SUPPORTS_UBSAN)
+    message(STATUS "Compiler supports UndefinedBehaviorSanitizer")
+    target_compile_options(pshell PRIVATE -fsanitize=undefined)
+    target_link_libraries(pshell PRIVATE -fsanitize=undefined)
+else()
+    message(WARNING "Compiler does not support UndefinedBehaviorSanitizer")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,11 @@ project(pshell C)
 
 set(CMAKE_C_STANDARD 99)
 
-include_directories(.)
-
 add_executable(pshell
-        shell.c
-        shell.h
-        cmd_parser.c)
+    shell.c
+    shell.h
+    cmd_parser.c
+)
 
 target_compile_options(pshell
     PRIVATE


### PR DESCRIPTION
Включил флаги компиляции и санитайзеров конкретному таргету вместо выставления их глобально с использованием команд `target_*`